### PR TITLE
Adds --cert-only and --create-listener flags

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:2.7-slim
 
 # This can be bumped every time you need to force an apt refresh
-ENV LAST_UPDATE 1
+ENV LAST_UPDATE 2
 
 RUN apt-get update && apt-get upgrade -y
 RUN apt-get update && apt-get install -y build-essential libffi-dev libssl-dev git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:2.7-slim
 
 # This can be bumped every time you need to force an apt refresh
-ENV LAST_UPDATE 2
+ENV LAST_UPDATE 3
 
 RUN apt-get update && apt-get upgrade -y
 RUN apt-get update && apt-get install -y build-essential libffi-dev libssl-dev git

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,5 @@ COPY letsencrypt-aws.py ./
 
 USER nobody
 
-ENTRYPOINT [".venv/bin/python", "letsencrypt-aws.py", "update-certificates"]
+ENTRYPOINT [".venv/bin/python", "letsencrypt-aws.py"]
+CMD ["update-certificates"]

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ The minimum set of permissions needed for `letsencrypt-aws` to work is:
 * `elasticloadbalancing:SetLoadBalancerListenerSSLCertificate`
 * `iam:ListServerCertificates`
 * `iam:UploadServerCertificate`
+* `iam:GetServerCertificate`
 
 If your `acme_account_key` is provided as an `s3://` URI you will also need:
 
@@ -155,6 +156,7 @@ An example IAM policy is:
             "Effect": "Allow",
             "Action": [
                 "iam:ListServerCertificates",
+                "iam:GetServerCertificate",
                 "iam:UploadServerCertificate"
             ],
             "Resource": [

--- a/letsencrypt-aws.py
+++ b/letsencrypt-aws.py
@@ -128,6 +128,9 @@ class Route53ChallengeCompleter(object):
                     (domain + ".").endswith(zone["Name"])
                 ):
                     return zone["Id"]
+        raise ValueError(
+            "Unable to find a Route53 hosted zone for {}".format(domain)
+        )
 
     def _change_txt_record(self, action, zone_id, domain, value):
         response = self.route53_client.change_resource_record_sets(

--- a/letsencrypt-aws.py
+++ b/letsencrypt-aws.py
@@ -126,11 +126,11 @@ def change_txt_record(route53_client, action, zone_id, domain, value):
 
 
 def generate_certificate_name(hosts, cert):
-    return "{hosts}-{expiration}-{serial}".format(
-        hosts="-".join(h.replace(".", "_") for h in hosts),
-        expiration=cert.not_valid_after.date(),
+    return "{serial}-{expiration}-{hosts}".format(
         serial=cert.serial,
-    )
+        expiration=cert.not_valid_after.date(),
+        hosts="-".join(h.replace(".", "_") for h in hosts),
+    )[:128]
 
 
 def get_load_balancer_certificate(elb_client, elb_name, elb_port):

--- a/letsencrypt-aws.py
+++ b/letsencrypt-aws.py
@@ -139,7 +139,6 @@ class Route53ChallengeCompleter(object):
         zones.sort(key=lambda z: len(z[0]), reverse=True)
         return zones[0][1]
 
-
     def _change_txt_record(self, action, zone_id, domain, value):
         response = self.route53_client.change_resource_record_sets(
             HostedZoneId=zone_id,

--- a/letsencrypt-aws.py
+++ b/letsencrypt-aws.py
@@ -170,7 +170,7 @@ def start_dns_challenge(logger, acme_client, elb_client, route53_client,
         "updating-elb.request-acme-challenge", elb_name=elb_name, host=host
     )
     authz = acme_client.request_domain_challenges(
-        host, new_authz_uri=acme_client.directory.new_authz
+        host, acme_client.directory.new_authz
     )
 
     [dns_challenge] = find_dns_challenge(authz)

--- a/letsencrypt-aws.py
+++ b/letsencrypt-aws.py
@@ -465,13 +465,6 @@ def update_certificates(persistent=False, force_issue=False):
     route53_client = session.client("route53")
     iam_client = session.client("iam")
 
-    # Structure: {
-    #     "domains": [
-    #         {"elb": {"name" "...", "port" 443}, hosts: ["..."]}
-    #     ],
-    #     "acme_account_key": "s3://bucket/object",
-    #     "acme_directory_url": "(optional)"
-    # }
     config = json.loads(os.environ["LETSENCRYPT_AWS_CONFIG"])
     domains = config["domains"]
     acme_directory_url = config.get(

--- a/letsencrypt-aws.py
+++ b/letsencrypt-aws.py
@@ -484,11 +484,18 @@ def update_certificates(persistent=False, force_issue=False):
 
     certificate_requests = []
     for domain in domains:
-        certificate_requests.append(CertificateRequest(
-            ELBCertificate(
+        if "elb" in domain:
+            cert_location = ELBCertificate(
                 elb_client, iam_client,
                 domain["elb"]["name"], int(domain["elb"].get("port", 443))
-            ),
+            )
+        else:
+            raise ValueError(
+                "Unknown certificate location: {!r}".format(domain)
+            )
+
+        certificate_requests.append(CertificateRequest(
+            cert_location,
             Route53ChallengeCompleter(route53_client),
             domain["hosts"],
             domain.get("key_type", "rsa"),

--- a/letsencrypt-aws.py
+++ b/letsencrypt-aws.py
@@ -462,7 +462,7 @@ def update_certificates(persistent=False, force_issue=False):
         certificate_requests.append(CertificateRequest(
             ELBCertificate(
                 elb_client, iam_client,
-                int(domain["elb"]["name"], domain["elb"].get("port", 443))
+                domain["elb"]["name"], int(domain["elb"].get("port", 443))
             ),
             Route53ChallengeCompleter(route53_client),
             domain["hosts"],

--- a/letsencrypt-aws.py
+++ b/letsencrypt-aws.py
@@ -462,7 +462,7 @@ def update_certificates(persistent=False, force_issue=False):
         certificate_requests.append(CertificateRequest(
             ELBCertificate(
                 elb_client, iam_client,
-                domain["elb"]["name"], domain["elb"].get("port", 443)
+                int(domain["elb"]["name"], domain["elb"].get("port", 443))
             ),
             Route53ChallengeCompleter(route53_client),
             domain["hosts"],


### PR DESCRIPTION
The --cert-only flag will create the certificate and does not attempt to
add the certificate to the ELB. This would allow you to then create the
listener manually (or some other method) with the new certificate.

The --create-listener flag will create the listener for the certificate
if it doesn't exist.
